### PR TITLE
Add concurrency to map and starmap operator

### DIFF
--- a/aiostream/manager.py
+++ b/aiostream/manager.py
@@ -17,6 +17,10 @@ class StreamerManager:
     def __init__(self, task_limit=None):
         """The number of concurrent task can be limited using the task_limit
         argument."""
+        # Argument check
+        if task_limit is not None and not task_limit > 0:
+            raise ValueError('The task limit must be None or greater than 0')
+        # Initialize internals
         self.pending = deque()
         self.task_limit = task_limit
         self.stack = AsyncExitStack()

--- a/aiostream/manager.py
+++ b/aiostream/manager.py
@@ -1,0 +1,88 @@
+"""Provide a context to easily manage several streamers running
+concurrently.
+"""
+
+import asyncio
+from collections import OrderedDict, deque
+
+from .core import streamcontext
+from .aiter_utils import anext
+from .context_utils import AsyncExitStack
+
+
+class StreamerManager:
+    """An asynchronous context manager to deal with several streamers running
+    concurrently."""
+
+    def __init__(self, task_limit=None):
+        """The number of concurrent task can be limited using the task_limit
+        argument."""
+        self.pending = deque()
+        self.task_limit = task_limit
+        self.stack = AsyncExitStack()
+        self.streamers = OrderedDict()
+
+    @property
+    def full(self):
+        """Indicates that the task limit has been reached."""
+        if self.task_limit is None:
+            return False
+        return len(self.streamers) >= self.task_limit
+
+    async def __aenter__(self):
+        """Asynchronous context manager support."""
+        await self.stack.__aenter__()
+        self.stack.callback(self.cleanup)
+        return self
+
+    async def __aexit__(self, *args):
+        """Asynchronous context manager support."""
+        return await self.stack.__aexit__(*args)
+
+    async def enter(self, source):
+        """Enter a stream and schedule the streamer in a safe manner."""
+        streamer = await self.stack.enter_context(streamcontext(source))
+        self.schedule(streamer)
+        return streamer
+
+    async def cleanup(self):
+        """Clean up all pending and active streamers."""
+        # Clear pending streamers
+        for streamer in self.pending:
+            await streamer.aclose()
+        self.pending.clear()
+        # Clear active streamers
+        for task, streamer in self.streamers.items():
+            task.cancel()
+            await streamer.aclose()
+        self.streamers.clear()
+
+    def schedule(self, streamer):
+        """Schedule the given streamer to produce its next item."""
+        # The task limit is reached
+        if self.full:
+            self.pending.append(streamer)
+        # Schedule next task
+        else:
+            task = asyncio.ensure_future(anext(streamer))
+            self.streamers[task] = streamer
+
+    def restore(self):
+        """Restore as many pending streamers as possible."""
+        while self.pending and not self.full:
+            self.schedule(self.pending.popleft())
+
+    async def completed(self):
+        """Asynchronously yield (streamer, getter) tuples as soon as the
+        scheduled streamers produce an item, or raise an exception."""
+        # Loop over wait operation
+        while self.streamers:
+            tasks = list(self.streamers)
+            # Sorted wait for first completed item
+            done, _ = await asyncio.wait(tasks, return_when="FIRST_COMPLETED")
+            for task in sorted(done, key=tasks.index):
+                # A cleanup can be performed between two yield statements
+                if task not in self.streamers:
+                    continue
+                # Yield a (streamer, getter) tuple
+                yield self.streamers.pop(task), task.result

--- a/aiostream/stream/advanced.py
+++ b/aiostream/stream/advanced.py
@@ -34,31 +34,41 @@ async def base_combine(source, switch=False, task_limit=None, ordered=False):
             # Get result
             try:
                 result = getter()
+
             # End of stream
             except StopAsyncIteration:
                 manager.restore()
                 finished[streamer] = True
+
             # Process result
             else:
+
                 # Switch mecanism
                 if switch and streamer is main_streamer:
                     results.clear()
                     await manager.cleanup()
+
                 # Setup a new source
                 if streamer is main_streamer:
                     results[await manager.enter(result)] = deque()
+
                 # Append the result
                 else:
                     results[streamer].append(result)
+
                 # Re-schedule streamer
                 manager.schedule(streamer)
 
             # Yield results
             for streamer, queue in results.items():
-                if ordered and not finished[streamer]:
-                    break
+
+                # Yield all items
                 while queue:
                     yield queue.popleft()
+
+                # Guarantee order
+                if ordered and not finished[streamer]:
+                    break
 
 
 # Advanced operators (for streams of higher order)

--- a/aiostream/stream/aggregate.py
+++ b/aiostream/stream/aggregate.py
@@ -13,7 +13,7 @@ async def accumulate(source, func=op.add, initializer=None):
     """Generate a series of accumulated sums (or other binary function)
     from an asynchronous sequence.
 
-    If initializer is present, it is placed before the items
+    If ``initializer`` is present, it is placed before the items
     of the sequence in the calculation, and serves as a default
     when the sequence is empty.
     """
@@ -42,7 +42,7 @@ def reduce(source, func, initializer=None):
     """Apply a function of two arguments cumulatively to the items
     of an asynchronous sequence, reducing the sequence to a single value.
 
-    If initializer is present, it is placed before the items
+    If ``initializer`` is present, it is placed before the items
     of the sequence in the calculation, and serves as a default when the
     sequence is empty.
     """

--- a/aiostream/stream/combine.py
+++ b/aiostream/stream/combine.py
@@ -81,21 +81,24 @@ def amap(source, corofn, *more_sources, ordered=True, task_limit=None):
     sequence is exhausted.
 
     The results can either be returned in or out of order, depending on
-    the corresponding ordered argument.
+    the corresponding ``ordered`` argument.
 
     The coroutines run concurrently but their amount can be limited using
-    the task_limit argument. A value of 1 will cause the coroutines to run
-    sequentially.
+    the ``task_limit`` argument. A value of ``1`` will cause the coroutines
+    to run sequentially.
 
-    Note: if more than one sequence is provided, they're also awaited
-    concurrently, so that their waiting times don't add up.
+    If more than one sequence is provided, they're also awaited concurrently,
+    so that their waiting times don't add up.
     """
-    op = lambda *args: create.just(corofn(*args))
+
+    def func(*args):
+        return create.just(corofn(*args))
+
     if ordered:
         return advanced.concatmap.raw(
-            source, op, *more_sources, task_limit=task_limit)
+            source, func, *more_sources, task_limit=task_limit)
     return advanced.flatmap.raw(
-        source, op, *more_sources, task_limit=task_limit)
+        source, func, *more_sources, task_limit=task_limit)
 
 
 @operator(pipable=True)
@@ -109,16 +112,16 @@ def map(source, func, *more_sources, ordered=True, task_limit=None):
     asynchronous (coroutine function).
 
     The results can either be returned in or out of order, depending on
-    the corresponding ordered argument. This argument is ignored if the
+    the corresponding ``ordered`` argument. This argument is ignored if the
     provided function is synchronous.
 
     The coroutines run concurrently but their amount can be limited using
-    the task_limit argument. A value of 1 will cause the coroutines to run
-    sequentially. This argument is ignored if the provided function is
-    synchronous.
+    the ``task_limit`` argument. A value of ``1`` will cause the coroutines
+    to run sequentially. This argument is ignored if the provided function
+    is synchronous.
 
-    Note: if more than one sequence is provided, they're also awaited
-    concurrently, so that their waiting times don't add up.
+    If more than one sequence is provided, they're also awaited concurrently,
+    so that their waiting times don't add up.
     """
     if asyncio.iscoroutinefunction(func):
         return amap.raw(

--- a/aiostream/stream/combine.py
+++ b/aiostream/stream/combine.py
@@ -53,29 +53,78 @@ async def zip(*sources):
 
 
 @operator(pipable=True)
-async def map(source, func, *more_sources):
+async def smap(source, func, *more_sources):
+    """Apply a given function to the elements of one or several
+    asynchronous sequences.
+
+    Each element is used as a positional argument, using the same order as
+    their respective sources. The generation continues until the shortest
+    sequence is exhausted. The function is treated synchronously.
+
+    Note: if more than one sequence is provided, they're awaited concurrently
+    so that their waiting times don't add up.
+    """
+    if more_sources:
+        source = zip(source, *more_sources)
+    async with streamcontext(source) as streamer:
+        async for item in streamer:
+            yield func(*item) if more_sources else func(item)
+
+
+@operator(pipable=True)
+def amap(source, corofn, *more_sources, ordered=True, task_limit=None):
+    """Apply a given coroutine function to the elements of one or several
+    asynchronous sequences.
+
+    Each element is used as a positional argument, using the same order as
+    their respective sources. The generation continues until the shortest
+    sequence is exhausted.
+
+    The results can either be returned in or out of order, depending on
+    the corresponding ordered argument.
+
+    The coroutines run concurrently but their amount can be limited using
+    the task_limit argument. A value of 1 will cause the coroutines to run
+    sequentially.
+
+    Note: if more than one sequence is provided, they're also awaited
+    concurrently, so that their waiting times don't add up.
+    """
+    op = lambda *args: create.just(corofn(*args))
+    if ordered:
+        return advanced.concatmap.raw(
+            source, op, *more_sources, task_limit=task_limit)
+    return advanced.flatmap.raw(
+        source, op, *more_sources, task_limit=task_limit)
+
+
+@operator(pipable=True)
+def map(source, func, *more_sources, ordered=True, task_limit=None):
     """Apply a given function to the elements of one or several
     asynchronous sequences.
 
     Each element is used as a positional argument, using the same order as
     their respective sources. The generation continues until the shortest
     sequence is exhausted. The function can either be synchronous or
-    asynchronous.
+    asynchronous (coroutine function).
 
-    Note: the different sequences are awaited in parallel, so that their
-    waiting times don't add up.
+    The results can either be returned in or out of order, depending on
+    the corresponding ordered argument. This argument is ignored if the
+    provided function is synchronous.
+
+    The coroutines run concurrently but their amount can be limited using
+    the task_limit argument. A value of 1 will cause the coroutines to run
+    sequentially. This argument is ignored if the provided function is
+    synchronous.
+
+    Note: if more than one sequence is provided, they're also awaited
+    concurrently, so that their waiting times don't add up.
     """
-    iscorofunc = asyncio.iscoroutinefunction(func)
-    if more_sources:
-        source = zip(source, *more_sources)
-    async with streamcontext(source) as streamer:
-        async for item in streamer:
-            if not more_sources:
-                item = (item,)
-            result = func(*item)
-            if iscorofunc:
-                result = await result
-            yield result
+    if asyncio.iscoroutinefunction(func):
+        return amap.raw(
+            source, func, *more_sources,
+            ordered=ordered, task_limit=task_limit)
+    return smap.raw(source, func, *more_sources)
 
 
 @operator(pipable=True)

--- a/aiostream/stream/create.py
+++ b/aiostream/stream/create.py
@@ -95,7 +95,7 @@ async def never():
 def repeat(value, times=None, *, interval=0):
     """Generate the same value a given number of times.
 
-    If times is None, the value is repeated indefinitely.
+    If ``times`` is ``None``, the value is repeated indefinitely.
     An optional interval can be given to space the values out.
     """
     args = () if times is None else (times,)
@@ -122,7 +122,7 @@ def count(start=0, step=1, *, interval=0):
     """Generate consecutive numbers indefinitely.
 
     Optional starting point and increment can be defined,
-    respectively defaulting to 0 and 1.
+    respectively defaulting to ``0`` and ``1``.
 
     An optional interval can be given to space the values out.
     """

--- a/aiostream/stream/create.py
+++ b/aiostream/stream/create.py
@@ -1,6 +1,7 @@
 """Non-pipable creation operators."""
 
 import asyncio
+import inspect
 import builtins
 import itertools
 import collections
@@ -56,8 +57,11 @@ async def preserve(ait):
 
 @operator
 async def just(value):
-    """Generate a single value."""
-    yield value
+    """Await if possible, and generate a single value."""
+    if inspect.isawaitable(value):
+        yield await value
+    else:
+        yield value
 
 
 @operator

--- a/aiostream/stream/select.py
+++ b/aiostream/stream/select.py
@@ -14,9 +14,9 @@ __all__ = ['take', 'takelast', 'skip', 'skiplast',
 
 @operator(pipable=True)
 async def take(source, n):
-    """Forward the first n elements from an asynchronous sequence.
+    """Forward the first ``n`` elements from an asynchronous sequence.
 
-    If n is negative, it simply terminates before iterating the source.
+    If ``n`` is negative, it simply terminates before iterating the source.
     """
     source = transform.enumerate.raw(source)
     async with streamcontext(source) as streamer:
@@ -30,9 +30,9 @@ async def take(source, n):
 
 @operator(pipable=True)
 async def takelast(source, n):
-    """Forward the last n elements from an asynchronous sequence.
+    """Forward the last ``n`` elements from an asynchronous sequence.
 
-    If n is negative, it simply terminates after iterating the source.
+    If ``n`` is negative, it simply terminates after iterating the source.
 
     Note: it is required to reach the end of the source before the first
     element is generated.
@@ -47,9 +47,9 @@ async def takelast(source, n):
 
 @operator(pipable=True)
 async def skip(source, n):
-    """Forward an asynchronous sequence, skipping the first n elements.
+    """Forward an asynchronous sequence, skipping the first ``n`` elements.
 
-    If n is negative, no elements are skipped.
+    If ``n`` is negative, no elements are skipped.
     """
     source = transform.enumerate.raw(source)
     async with streamcontext(source) as streamer:
@@ -60,11 +60,11 @@ async def skip(source, n):
 
 @operator(pipable=True)
 async def skiplast(source, n):
-    """Forward an asynchronous sequence, skipping the last n elements.
+    """Forward an asynchronous sequence, skipping the last ``n`` elements.
 
-    If n is negative, no elements are skipped.
+    If ``n`` is negative, no elements are skipped.
 
-    Note: it is required to reach the (n+1)th element of the source
+    Note: it is required to reach the ``n+1`` th element of the source
     before the first element is generated.
     """
     queue = collections.deque(maxlen=n if n > 0 else 0)
@@ -83,8 +83,8 @@ async def filterindex(source, func):
     """Filter an asynchronous sequence using the index of the elements.
 
     The given function is synchronous, takes the index as an argument,
-    and returns True if the corresponding should be forwarded,
-    False otherwise.
+    and returns ``True`` if the corresponding should be forwarded,
+    ``False`` otherwise.
     """
     source = transform.enumerate.raw(source)
     async with streamcontext(source) as streamer:
@@ -99,8 +99,8 @@ def slice(source, *args):
 
     The arguments are the same as the builtin type slice.
 
-    There two limitations compare to regular slices:
-    - Positive stop index + negative start index is not supported
+    There are two limitations compare to regular slices:
+    - Positive stop index with negative start index is not supported
     - Negative step is not supported
     """
     s = builtins.slice(*args)
@@ -114,7 +114,7 @@ def slice(source, *args):
     if stop is not None:
         if stop >= 0 and start < 0:
             raise ValueError(
-                "Positive stop + negative start is not supported")
+                "Positive stop with negative start is not supported")
         elif stop >= 0:
             source = take.raw(source, stop - start)
         else:
@@ -131,10 +131,10 @@ def slice(source, *args):
 
 @operator(pipable=True)
 async def item(source, index):
-    """Forward the nth element of an asynchronous sequence.
+    """Forward the ``n``th element of an asynchronous sequence.
 
     The index can be negative and works like regular indexing.
-    If the index is out of range, and IndexError is raised.
+    If the index is out of range, and ``IndexError`` is raised.
     """
     # Prepare
     if index >= 0:
@@ -176,8 +176,8 @@ def getitem(source, index):
 async def filter(source, func):
     """Filter an asynchronous sequence using an arbitrary function.
 
-    The function takes the item as an argument and returns True
-    if it should be forwarded, False otherwise.
+    The function takes the item as an argument and returns ``True``
+    if it should be forwarded, ``False`` otherwise.
     The function can either be synchronous or asynchronous.
     """
     iscorofunc = asyncio.iscoroutinefunction(func)

--- a/aiostream/stream/transform.py
+++ b/aiostream/stream/transform.py
@@ -12,10 +12,10 @@ __all__ = ['map', 'enumerate', 'starmap', 'cycle', 'chunks']
 
 @operator(pipable=True)
 async def enumerate(source, start=0, step=1):
-    """Generate (index, value) tuples from an asynchronous sequence.
+    """Generate ``(index, value)`` tuples from an asynchronous sequence.
 
     This index is computed using a starting point and an increment,
-    respectively defaulting to 0 and 1.
+    respectively defaulting to ``0`` and ``1``.
     """
     count = itertools.count(start, step)
     async with streamcontext(source) as streamer:
@@ -32,13 +32,13 @@ def starmap(source, func, ordered=True, task_limit=None):
     The given function can either be synchronous or asynchronous.
 
     The results can either be returned in or out of order, depending on
-    the corresponding ordered argument. This argument is ignored if the
-    provided function is synchronous.
+    the corresponding ``ordered`` argument. This argument is ignored if
+    the provided function is synchronous.
 
     The coroutines run concurrently but their amount can be limited using
-    the task_limit argument. A value of 1 will cause the coroutines to run
-    sequentially. This argument is ignored if the provided function is
-    synchronous.
+    the ``task_limit`` argument. A value of ``1`` will cause the coroutines
+    to run sequentially. This argument is ignored if the provided function
+    is synchronous.
     """
     if asyncio.iscoroutinefunction(func):
         async def starfunc(args):
@@ -68,9 +68,9 @@ async def cycle(source):
 
 @operator(pipable=True)
 async def chunks(source, n):
-    """Generate chunks of size n from an asynchronous sequence.
+    """Generate chunks of size ``n`` from an asynchronous sequence.
 
-    The chunks are lists, and the last chunk might contain less than n
+    The chunks are lists, and the last chunk might contain less than ``n``
     elements.
     """
     async with streamcontext(source) as streamer:

--- a/aiostream/stream/transform.py
+++ b/aiostream/stream/transform.py
@@ -24,12 +24,21 @@ async def enumerate(source, start=0, step=1):
 
 
 @operator(pipable=True)
-def starmap(source, func):
+def starmap(source, func, ordered=True, task_limit=None):
     """Apply a given function to the unpacked elements of
     an asynchronous sequence.
 
     Each element is unpacked before applying the function.
     The given function can either be synchronous or asynchronous.
+
+    The results can either be returned in or out of order, depending on
+    the corresponding ordered argument. This argument is ignored if the
+    provided function is synchronous.
+
+    The coroutines run concurrently but their amount can be limited using
+    the task_limit argument. A value of 1 will cause the coroutines to run
+    sequentially. This argument is ignored if the provided function is
+    synchronous.
     """
     if asyncio.iscoroutinefunction(func):
         async def starfunc(args):
@@ -37,7 +46,7 @@ def starmap(source, func):
     else:
         def starfunc(args):
             return func(*args)
-    return map.raw(source, starfunc)
+    return map.raw(source, starfunc, ordered=ordered, task_limit=task_limit)
 
 
 @operator(pipable=True)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,10 +25,15 @@ aiostream
 Generator-based operators for asynchronous iteration
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    presentation
    operators
    core
    examples
    utilities
+
+Reference table:
+
+.. module:: aiostream.stream
+.. include:: table.rst.inc

--- a/docs/operators.rst
+++ b/docs/operators.rst
@@ -65,8 +65,8 @@ Transformation operators
 
 .. autoclass:: map
 
-   Note: :class:`map` is considered a combination operator
-   if used with extra sources, and a transformation operator otherwise
+   .. note:: :class:`map` is considered a combination operator
+	     if used with extra sources, and a transformation operator otherwise
 
 .. autoclass:: enumerate
 
@@ -100,8 +100,8 @@ Combination operators
 
 .. autoclass:: map
 
-   Note: :class:`map` is considered a combination operator
-   if used with extra sources, and a transformation operator otherwise
+   .. note:: :class:`map` is considered a combination operator
+	     if used with extra sources, and a transformation operator otherwise
 
 .. autoclass:: zip
 

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -9,30 +9,78 @@ assert_run, event_loop
 
 @pytest.mark.asyncio
 async def test_concatmap(assert_run, event_loop):
+    # Concurrent run
     with event_loop.assert_cleanup():
         xs = stream.range(0, 6, 2, interval=1)
         ys = xs | pipe.concatmap(lambda x: stream.range(x, x+2, interval=5))
         await assert_run(ys, [0, 1, 2, 3, 4, 5])
         assert event_loop.steps == [1, 1, 3, 1, 1]
 
+    # Sequential run
+    with event_loop.assert_cleanup():
+        xs = stream.range(0, 6, 2, interval=1)
+        ys = xs | pipe.concatmap(
+            lambda x: stream.range(x, x+2, interval=5),
+            task_limit=1)
+        await assert_run(ys, [0, 1, 2, 3, 4, 5])
+        assert event_loop.steps == [5, 1, 5, 1, 5]
+
+    # Limited run
+    with event_loop.assert_cleanup():
+        xs = stream.range(0, 6, 2, interval=1)
+        ys = xs | pipe.concatmap(
+            lambda x: stream.range(x, x+2, interval=5),
+            task_limit=2)
+        await assert_run(ys, [0, 1, 2, 3, 4, 5])
+        assert event_loop.steps == [1, 4, 1, 5]
+
+    # Make sure item arrive as soon as possible
+    with event_loop.assert_cleanup():
+        xs = stream.just(2)
+        ys = xs | pipe.concatmap(lambda x: stream.range(x, x+4, interval=1))
+        zs = ys | pipe.timeout(2)  # Sould NOT raise
+        await assert_run(zs, [2, 3, 4, 5])
+        assert event_loop.steps == [1, 1, 1]
+
 
 @pytest.mark.asyncio
 async def test_flatmap(assert_run, event_loop):
+    # Concurrent run
     with event_loop.assert_cleanup():
-        xs = stream.range(0, 3, interval=1)
-        ys = xs | pipe.flatmap(lambda x: stream.range(x, x+6, 3, interval=3))
+        xs = stream.range(0, 6, 2, interval=1)
+        ys = xs | pipe.flatmap(lambda x: stream.range(x, x+2, interval=5))
+        await assert_run(ys, [0, 2, 4, 1, 3, 5])
+        assert event_loop.steps == [1, 1, 3, 1, 1]
+
+    # Sequential run
+    with event_loop.assert_cleanup():
+        xs = stream.range(0, 6, 2, interval=1)
+        ys = xs | pipe.flatmap(
+            lambda x: stream.range(x, x+2, interval=5),
+            task_limit=1)
         await assert_run(ys, [0, 1, 2, 3, 4, 5])
-        assert event_loop.steps == [1, 1, 1, 1, 1]
+        assert event_loop.steps == [5, 1, 5, 1, 5]
+
+    # Limited run
+    with event_loop.assert_cleanup():
+        xs = stream.range(0, 6, 2, interval=1)
+        ys = xs | pipe.flatmap(
+            lambda x: stream.range(x, x+2, interval=5),
+            task_limit=2)
+        await assert_run(ys, [0, 2, 1, 3, 4, 5])
+        assert event_loop.steps == [1, 4, 1, 5]
 
 
 @pytest.mark.asyncio
 async def test_switchmap(assert_run, event_loop):
-    with event_loop.assert_cleanup():
-        xs = stream.range(0, 5, interval=1)
-        ys = xs | pipe.switchmap(lambda x: stream.range(x, x+2, interval=2))
-        await assert_run(ys, [0, 1, 2, 3, 4, 5])
-        assert event_loop.steps == [1, 1, 1, 1, 1, 1]
 
+    with event_loop.assert_cleanup():
+        xs = stream.range(0, 30, 10, interval=3)
+        ys = xs | pipe.switchmap(lambda x: stream.range(x, x+5, interval=1))
+        await assert_run(ys, [0, 1, 2, 10, 11, 12, 20, 21, 22, 23, 24])
+        assert event_loop.steps == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+    # Test cleanup procedure
     with event_loop.assert_cleanup():
         xs = stream.range(0, 5, interval=1)
         ys = xs | pipe.switchmap(lambda x: stream.range(x, x+2, interval=2))

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -1,0 +1,40 @@
+import pytest
+
+from aiostream import stream, pipe
+from aiostream.test_utils import assert_run, event_loop
+
+# Pytest fixtures
+assert_run, event_loop
+
+
+@pytest.mark.asyncio
+async def test_concatmap(assert_run, event_loop):
+    with event_loop.assert_cleanup():
+        xs = stream.range(0, 6, 2, interval=1)
+        ys = xs | pipe.concatmap(lambda x: stream.range(x, x+2, interval=5))
+        await assert_run(ys, [0, 1, 2, 3, 4, 5])
+        assert event_loop.steps == [1, 1, 3, 1, 1]
+
+
+@pytest.mark.asyncio
+async def test_flatmap(assert_run, event_loop):
+    with event_loop.assert_cleanup():
+        xs = stream.range(0, 3, interval=1)
+        ys = xs | pipe.flatmap(lambda x: stream.range(x, x+6, 3, interval=3))
+        await assert_run(ys, [0, 1, 2, 3, 4, 5])
+        assert event_loop.steps == [1, 1, 1, 1, 1]
+
+
+@pytest.mark.asyncio
+async def test_switchmap(assert_run, event_loop):
+    with event_loop.assert_cleanup():
+        xs = stream.range(0, 5, interval=1)
+        ys = xs | pipe.switchmap(lambda x: stream.range(x, x+2, interval=2))
+        await assert_run(ys, [0, 1, 2, 3, 4, 5])
+        assert event_loop.steps == [1, 1, 1, 1, 1, 1]
+
+    with event_loop.assert_cleanup():
+        xs = stream.range(0, 5, interval=1)
+        ys = xs | pipe.switchmap(lambda x: stream.range(x, x+2, interval=2))
+        await assert_run(ys[:3], [0, 1, 2])
+        assert event_loop.steps == [1, 1]

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -31,30 +31,75 @@ async def test_zip(assert_run, event_loop):
 
 @pytest.mark.asyncio
 async def test_map(assert_run, event_loop):
+
+    # Synchronous/simple
     with event_loop.assert_cleanup():
         xs = stream.range(5) | pipe.map(lambda x: x**2)
         expected = [x**2 for x in range(5)]
         await assert_run(xs, expected)
 
+    # Synchronous/multiple
     with event_loop.assert_cleanup():
         xs = stream.range(5)
         ys = xs | pipe.map(lambda x, y: x+y, xs)
         expected = [x*2 for x in range(5)]
         await assert_run(ys, expected)
 
+    # Asynchronous/simple/concurrent
     with event_loop.assert_cleanup():
         xs = stream.range(1, 4) | pipe.map(asyncio.sleep)
         expected = [None] * 3
         await assert_run(xs, expected)
+        assert event_loop.steps == [1, 1, 1]
+
+    # Asynchronous/simple/sequential
+    with event_loop.assert_cleanup():
+        xs = stream.range(1, 4) | pipe.map(asyncio.sleep, task_limit=1)
+        expected = [None] * 3
+        await assert_run(xs, expected)
         assert event_loop.steps == [1, 2, 3]
 
+    # Asynchronous/multiple/concurrent
     with event_loop.assert_cleanup():
         xs = stream.range(1, 4)
         ys = xs | pipe.map(asyncio.sleep, xs)
         await assert_run(ys, [1, 2, 3])
+        assert event_loop.steps == [1, 1, 1]
+        event_loop.steps.clear()
+
+    # Asynchronous/multiple/sequential
+    with event_loop.assert_cleanup():
+        xs = stream.range(1, 4)
+        ys = xs | pipe.map(asyncio.sleep, xs, task_limit=1)
+        await assert_run(ys, [1, 2, 3])
         assert event_loop.steps == [1, 2, 3]
         event_loop.steps.clear()
 
+    # As completed
+    with event_loop.assert_cleanup():
+        xs = stream.iterate([2, 4, 1, 3, 5])
+        ys = xs | pipe.map(asyncio.sleep, xs, ordered=False)
+        await assert_run(ys, [1, 2, 3, 4, 5])
+        assert event_loop.steps == [1, 1, 1, 1, 1]
+        event_loop.steps.clear()
+
+    # Invalid argument
+    with pytest.raises(ValueError):
+        await (stream.range(1, 4) | pipe.map(asyncio.sleep, task_limit=0))
+
+    # Break
+    with event_loop.assert_cleanup():
+        xs = stream.count(1)
+        ys = xs | pipe.map(asyncio.sleep, xs, task_limit=10)
+        await assert_run(ys[:3], [1, 2, 3])
+        assert event_loop.steps == [1, 1, 1]
+        event_loop.steps.clear()
+
+    # Stuck
+    with event_loop.assert_cleanup():
+        xs = stream.count(1)
+        ys = xs | pipe.map(asyncio.sleep, xs, task_limit=1) | pipe.timeout(5)
+        await assert_run(ys, [1, 2, 3, 4], asyncio.TimeoutError())
 
 @pytest.mark.asyncio
 async def test_merge(assert_run, event_loop):
@@ -67,38 +112,5 @@ async def test_merge(assert_run, event_loop):
     with event_loop.assert_cleanup():
         xs = stream.range(1, 5, 2, interval=2) | pipe.delay(1)
         ys = stream.range(0, 5, 2, interval=2) | pipe.merge(xs)
-        await assert_run(ys[:3], [0, 1, 2])
-        assert event_loop.steps == [1, 1]
-
-
-@pytest.mark.asyncio
-async def test_concatmap(assert_run, event_loop):
-    with event_loop.assert_cleanup():
-        xs = stream.range(0, 6, 2, interval=1)
-        ys = xs | pipe.concatmap(lambda x: stream.range(x, x + 2, interval=1))
-        await assert_run(ys, [0, 1, 2, 3, 4, 5])
-        assert event_loop.steps == [1, 1, 1, 1, 1]
-
-
-@pytest.mark.asyncio
-async def test_flatmap(assert_run, event_loop):
-    with event_loop.assert_cleanup():
-        xs = stream.range(0, 3, interval=1)
-        ys = xs | pipe.flatmap(lambda x: stream.range(x, x+6, 3, interval=3))
-        await assert_run(ys, [0, 1, 2, 3, 4, 5])
-        assert event_loop.steps == [1, 1, 1, 1, 1]
-
-
-@pytest.mark.asyncio
-async def test_switchmap(assert_run, event_loop):
-    with event_loop.assert_cleanup():
-        xs = stream.range(0, 5, interval=1)
-        ys = xs | pipe.switchmap(lambda x: stream.range(x, x+2, interval=2))
-        await assert_run(ys, [0, 1, 2, 3, 4, 5])
-        assert event_loop.steps == [1, 1, 1, 1, 1, 1]
-
-    with event_loop.assert_cleanup():
-        xs = stream.range(0, 5, interval=1)
-        ys = xs | pipe.switchmap(lambda x: stream.range(x, x+2, interval=2))
         await assert_run(ys[:3], [0, 1, 2])
         assert event_loop.steps == [1, 1]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -23,6 +23,13 @@ async def test_starmap(assert_run, event_loop):
         ys = stream.range(1, 4)
         zs = xs | pipe.zip(ys) | pipe.starmap(asyncio.sleep)
         await assert_run(zs, [1, 2, 3])
+        assert event_loop.steps == [1, 1, 1]
+
+    with event_loop.assert_cleanup():
+        xs = stream.range(1, 4)
+        ys = stream.range(1, 4)
+        zs = xs | pipe.zip(ys) | pipe.starmap(asyncio.sleep, task_limit=1)
+        await assert_run(zs, [1, 2, 3])
         assert event_loop.steps == [1, 2, 3]
 
 


### PR DESCRIPTION
- Refactor advanced operators so they provide the same control over concurrent subsequences.
- Use this new implementation to add concurrency to the `map` and `starmap` operators
- Improve  docs and tests


