### PR TITLE
Raise a better exception when decorating a method with @operator

### DIFF
--- a/aiostream/core.py
+++ b/aiostream/core.py
@@ -254,12 +254,18 @@ def operator(func=None, *, pipable=False):
         # Extract signature
         signature = inspect.signature(func)
         parameters = list(signature.parameters.values())
+        if parameters and parameters[0].name in ('self', 'cls'):
+            raise ValueError(
+                'An operator cannot be created from a method, '
+                'since the decorated function becomes an operator class')
+
+        # Injected parameters
         self_parameter = inspect.Parameter(
             'self', inspect.Parameter.POSITIONAL_OR_KEYWORD)
         cls_parameter = inspect.Parameter(
             'cls', inspect.Parameter.POSITIONAL_OR_KEYWORD)
 
-        # wrapped static method
+        # Wrapped static method
         original = func
         original.__qualname__ = name + '.original'
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,8 +1,7 @@
 import pytest
-import asyncio
 
 from aiostream.test_utils import event_loop, add_resource
-from aiostream import stream, streamcontext
+from aiostream import stream, streamcontext, operator
 
 # Pytest fixtures
 event_loop
@@ -26,3 +25,25 @@ async def test_streamcontext(event_loop):
             async for item in streamer:
                 assert item == next(it)
         assert event_loop.steps == [1]
+
+
+def test_operator_from_method():
+
+    with pytest.raises(ValueError):
+        class A:
+            @operator
+            async def method(self, arg):
+                yield 1
+
+    with pytest.raises(ValueError):
+        class B:
+            @operator
+            async def method(cls, arg):
+                yield 1
+
+    with pytest.raises(AttributeError):
+        class C:
+            @operator
+            @classmethod
+            async def method(cls, arg):
+                yield 1


### PR DESCRIPTION
Fix issue #23.