### PR TITLE
Refactor base_combine and the streamer manager

### DIFF
--- a/aiostream/stream/create.py
+++ b/aiostream/stream/create.py
@@ -4,7 +4,8 @@ import asyncio
 import inspect
 import builtins
 import itertools
-import collections
+
+from collections.abc import Iterable
 
 from ..stream import time
 from ..core import operator, streamcontext
@@ -39,7 +40,7 @@ def iterate(it):
     """Generate values from a sychronous or asynchronous iterable."""
     if is_async_iterable(it):
         return from_async_iterable.raw(it)
-    if isinstance(it, collections.Iterable):
+    if isinstance(it, Iterable):
         return from_iterable.raw(it)
     raise TypeError(
         f"{type(it).__name__!r} object is not (async) iterable")

--- a/aiostream/stream/time.py
+++ b/aiostream/stream/time.py
@@ -8,6 +8,20 @@ from ..core import operator, streamcontext
 __all__ = ['spaceout', 'delay', 'timeout']
 
 
+async def wait_for(aw, timeout):
+    task = asyncio.ensure_future(aw)
+    try:
+        return await asyncio.wait_for(task, timeout)
+    finally:
+        # Python 3.6 compatibility
+        if not task.done():  # pragma: no cover
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+
 @operator(pipable=True)
 async def spaceout(source, interval):
     """Make sure the elements of an asynchronous sequence are separated
@@ -35,7 +49,7 @@ async def timeout(source, timeout):
     async with streamcontext(source) as streamer:
         while True:
             try:
-                item = await asyncio.wait_for(anext(streamer), timeout)
+                item = await wait_for(anext(streamer), timeout)
             except StopAsyncIteration:
                 break
             else:

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -14,7 +14,7 @@ async def test_concatmap(assert_run, event_loop):
         xs = stream.range(0, 6, 2, interval=1)
         ys = xs | pipe.concatmap(lambda x: stream.range(x, x+2, interval=5))
         await assert_run(ys, [0, 1, 2, 3, 4, 5])
-        assert event_loop.steps == [1, 1, 3, 1, 1]
+        assert event_loop.steps == [1, 1, 3, 5, 5]
 
     # Sequential run
     with event_loop.assert_cleanup():
@@ -32,7 +32,7 @@ async def test_concatmap(assert_run, event_loop):
             lambda x: stream.range(x, x+2, interval=5),
             task_limit=2)
         await assert_run(ys, [0, 1, 2, 3, 4, 5])
-        assert event_loop.steps == [1, 4, 1, 5]
+        assert event_loop.steps == [1, 4, 1, 4, 5]
 
     # Make sure item arrive as soon as possible
     with event_loop.assert_cleanup():


### PR DESCRIPTION
This PR includes a complete refactoring of `base_combine` and the streamer manager. 

The behavior is slightly modified for the `concatmap` use case: the substreams won't get iterated further than the first item, until it's their turn to yield items to the consumer. Those items used to get cached, which doesn't really fit the philosophy of the library and introduces some hard-to-predict behavior.

Note: this change doesn't affect the behavior of ordered `map` since the substreams only contains one item.

This PR also adds a new TaskGroup class (name inspired by [agronholm/anyio](https://github.com/agronholm/anyio)). This class gathers all the asyncio-specific calls to facilitate the support of other async libraries, see issue #17, PR #25.

