### PR TITLE
[fix] set encoding to utf-8 in setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ UPLOAD = 'upload_sphinx' in sys.argv
 if not UPLOAD and sys.version_info < (3, 6):
     raise RuntimeError("aiostream requires Python 3.6")
 
-with open("README.rst") as f:
+with open("README.rst", encoding="utf-8") as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
Hi,

I like to install a library that requires aiostream, but it fails to install with the version on pypi because the README.md has some UTF-8 text that is not encoded correctly. This commit fixes it by encoding the README.md-file as UTF-8 correctly.

The error I got during install is this, the code at position 4348 is the "²" in the print:
```
Collecting aiostream==0.3.2 (from -r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/b1/8b/a8bd71c931c424d37a6336fd7a2df4c6b9432847c9752b7809f0e1d9aa7e/aiostream-0.3.2.tar.gz
    ERROR: Command errored out with exit status 1:
     command: /hidigitpro/virtualenv/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-31uw9tpb/aiostream/setup.py'"'"'; __file__='"'"'/tmp/pip-install-31uw9tpb/aiostream/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info
         cwd: /tmp/pip-install-31uw9tpb/aiostream/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-31uw9tpb/aiostream/setup.py", line 12, in <module>
        long_description = f.read()
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 4348: ordinal not in range(128)
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```