### PR TITLE
Copy pending set before iterating and discarding

### DIFF
--- a/aiostream/manager.py
+++ b/aiostream/manager.py
@@ -17,7 +17,7 @@ class TaskGroup:
         return self
 
     async def __aexit__(self, *args):
-        for task in self._pending:
+        for task in self._pending.copy():
             await self.cancel_task(task)  # pragma: no cover
 
     def create_task(self, coro):


### PR DESCRIPTION
Calling `self.cancel_task` in `__aexit__` was never safe when having
pending tasks. Since `self.cancel_tasks` modifies `self._pending` we
need to copy the set and iterate over that snapshot.

This fixes vxgmichel/aiostream#73