### PR TITLE
Fix several issues with the task group

### DIFF
--- a/aiostream/manager.py
+++ b/aiostream/manager.py
@@ -17,8 +17,9 @@ class TaskGroup:
         return self
 
     async def __aexit__(self, *args):
-        for task in self._pending:
-            await self.cancel_task(task)  # pragma: no cover
+        while self._pending:
+            task = self._pending.pop()
+            await self.cancel_task(task)
 
     def create_task(self, coro):
         task = asyncio.ensure_future(coro)

--- a/aiostream/test_utils.py
+++ b/aiostream/test_utils.py
@@ -35,16 +35,17 @@ def compare_exceptions(exc1, exc2):
 
 async def assert_aiter(source, values, exception=None):
     """Check the results of a stream using a streamcontext."""
-    it = iter(values)
+    results = []
     exception_type = type(exception) if exception else ()
     try:
         async with streamcontext(source) as streamer:
             async for item in streamer:
-                assert item == next(it)
+                results.append(item)
     except exception_type as exc:
         assert compare_exceptions(exc, exception)
     else:
         assert exception is None
+    assert results == values
 
 
 async def assert_await(source, values, exception=None):

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -55,7 +55,8 @@ async def test_reduce(assert_run, event_loop):
 async def test_list(assert_run, event_loop):
     with event_loop.assert_cleanup():
         xs = stream.range(3) | add_resource.pipe(1) | pipe.list()
-        await assert_run(xs, [[], [0], [0, 1], [0, 1, 2]])
+        # The same list object is yielded at each step
+        await assert_run(xs, [[0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2]])
 
     with event_loop.assert_cleanup():
         xs = stream.range(0) | add_resource.pipe(1) | pipe.list()

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -144,6 +144,23 @@ async def test_merge(assert_run, event_loop):
         zs = stream.merge(xs, ys) | pipe.delay(1) | pipe.take(3)
         await assert_run(zs, [1, 2, 3])
 
+    # Silencing of a CancelledError
+
+    async def agen1():
+        if False:
+            yield
+        try:
+            await asyncio.sleep(2)
+        except asyncio.CancelledError:
+            return
+
+    async def agen2():
+        yield 1
+
+    with event_loop.assert_cleanup():
+        xs = stream.merge(agen1(), agen2()) | pipe.delay(1) | pipe.take(1)
+        await assert_run(xs, [1])
+
 
 @pytest.mark.asyncio
 async def test_ziplatest(assert_run, event_loop):

--- a/tests/test_task_group.py
+++ b/tests/test_task_group.py
@@ -1,0 +1,53 @@
+import asyncio
+
+import pytest
+from aiostream.manager import TaskGroup
+
+
+async def task1():
+    await asyncio.sleep(1)
+    return 1
+
+
+async def task2():
+    await asyncio.sleep(0)
+    return 2
+
+
+async def task3():
+    await asyncio.sleep(0)
+    raise ValueError(3)
+
+
+async def task4():
+    await asyncio.sleep(1)
+    raise ValueError(4)
+
+
+async def task5():
+    try:
+        await asyncio.sleep(1)
+    finally:
+        raise ValueError(5)
+
+
+@pytest.mark.asyncio
+async def test_task_group_cleanup(event_loop):
+    async with TaskGroup() as group:
+        t1 = group.create_task(task1())
+        t2 = group.create_task(task2())
+        t3 = group.create_task(task3())
+        t4 = group.create_task(task4())
+        t5 = group.create_task(task5())
+        # Cancel task1
+        t1.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await t1
+        assert t1.cancelled()
+        # Join task2
+        assert await t2 == 2
+        # Task 3 is finished
+        assert t3.done()
+        # Task 4 and 5 are not finished
+        assert not t4.done()
+        assert not t5.done()


### PR DESCRIPTION
Fix #73

Includes:
- Checking `more_sources` argument types at stream instantiation
- Fix the `TaskGroup` exit method by popping the tasks from the pending set
- Fix the `TaskGoup.cancel_task` method by always discarding the tasks
- Add more tests