### PR TITLE
Add sources_operators

### DIFF
--- a/aiostream/core.py
+++ b/aiostream/core.py
@@ -349,14 +349,6 @@ def operator(
             "since the decorated function becomes an operator class"
         )
 
-    # Look for "more_sources"
-    for i, p in enumerate(parameters):
-        if p.name == "more_sources" and p.kind == inspect.Parameter.VAR_POSITIONAL:
-            more_sources_index = i
-            break
-    else:
-        more_sources_index = None
-
     # Injected parameters
     self_parameter = inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD)
     inspect.Parameter("cls", inspect.Parameter.POSITIONAL_OR_KEYWORD)
@@ -371,9 +363,6 @@ def operator(
 
     # Init method
     def init(self: BaseStream[T], *args: P.args, **kwargs: P.kwargs) -> None:
-        if more_sources_index is not None:
-            for source in args[more_sources_index:]:
-                assert_async_iterable(source)
         factory = functools.partial(raw, *args, **kwargs)
         return BaseStream.__init__(self, factory)
 

--- a/aiostream/stream/create.py
+++ b/aiostream/stream/create.py
@@ -16,7 +16,7 @@ from typing import (
     AsyncIterator,
     cast,
 )
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, Never
 
 from ..stream import time
 from ..core import operator, streamcontext
@@ -121,7 +121,7 @@ async def call(
 
 
 @operator
-async def throw(exc: Exception) -> AsyncIterator[None]:
+async def throw(exc: Exception) -> AsyncIterator[Never]:
     """Throw an exception without generating any value."""
     if False:
         yield
@@ -129,14 +129,14 @@ async def throw(exc: Exception) -> AsyncIterator[None]:
 
 
 @operator
-async def empty() -> AsyncIterator[None]:
+async def empty() -> AsyncIterator[Never]:
     """Terminate without generating any value."""
     if False:
         yield
 
 
 @operator
-async def never() -> AsyncIterator[None]:
+async def never() -> AsyncIterator[Never]:
     """Hang forever without generating any value."""
     if False:
         yield

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -27,6 +27,12 @@ async def test_zip(assert_run, event_loop):
     expected = [(x,) * 3 for x in range(5)]
     await assert_run(ys, expected)
 
+    # Empty zip (issue #95)
+
+    with event_loop.assert_cleanup():
+        xs = stream.zip()
+        await assert_run(xs, [])
+
 
 @pytest.mark.asyncio
 async def test_map(assert_run, event_loop):
@@ -160,6 +166,12 @@ async def test_merge(assert_run, event_loop):
         xs = stream.merge(agen1(), agen2()) | pipe.delay(1) | pipe.take(1)
         await assert_run(xs, [1])
 
+    # Empty merge (issue #95)
+
+    with event_loop.assert_cleanup():
+        xs = stream.merge()
+        await assert_run(xs, [])
+
 
 @pytest.mark.asyncio
 async def test_ziplatest(assert_run, event_loop):
@@ -176,3 +188,11 @@ async def test_ziplatest(assert_run, event_loop):
         zs = stream.ziplatest(xs, ys, partial=False)
         await assert_run(zs, [(0, 1), (2, 1), (2, 3), (4, 3)])
         assert event_loop.steps == [1, 1, 1, 1]
+
+    # Empty ziplatest (issue #95)
+    # This not supported yet due to the `sources_operator` decorator
+    # not supporting keyword arguments.
+    #
+    # with event_loop.assert_cleanup():
+    #     xs = stream.ziplatest()
+    #     await assert_run(xs, [])


### PR DESCRIPTION
An attempt to address issue #95 by adding another `*operator` decorator dedicated to operators that can take zero, one or many async iterables as arguments.

There are two issues with this attempt: 
- the new decorator does not support operator with keyword arguments, so an empty `ziplatest()` is still not supported.
- this break proper type inference for the `merge` and `zip` operators, as seen here: 
  https://github.com/vxgmichel/aiostream/pull/96/files#diff-013a68594b5bfcc0727109dc487131baf28839aa529c426944bdfb467edbc02cR265