### PR TITLE
Configure pytest test paths so test_utils.py is not mistaken for a test file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ Homepage = "https://github.com/vxgmichel/aiostream"
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers --cov aiostream"
+testpaths = ["tests"]
 
 [tool.pyright]
 strict = [


### PR DESCRIPTION
See issue #115