### PR TITLE
feat: prefetch

### DIFF
--- a/aiostream/pipe.py
+++ b/aiostream/pipe.py
@@ -38,3 +38,4 @@ timeout = stream.timeout.pipe
 until = stream.until.pipe
 zip = stream.zip.pipe
 ziplatest = stream.ziplatest.pipe
+prefetch = stream.prefetch.pipe

--- a/aiostream/stream/transform.py
+++ b/aiostream/stream/transform.py
@@ -158,5 +158,5 @@ async def prefetch(source: AsyncIterable[T], buffer_size: int = 1) -> AsyncItera
         worker.cancel()
         try:
             await worker
-        except (asyncio.CancelledError, Exception):
+        except asyncio.CancelledError:
             pass


### PR DESCRIPTION
This request concerns a new pipeable operator: `prefetch`. Initially, it was just a utility I put together for a neural network data loader. However, it may also make a good PR. 

The utility can help prevent pipeline starvation by eagerly fetching items before they're needed. I inserted mine before a bottleneck in my training loop (the forward/backward pass). 

This addition ensures that my data loader is already preparing the next batch while the model is processing the current one. Thus, each batch starts before the previous one finishes training, preventing the system from starving my accelerators.