### PR TITLE
Improve performance for sequential combine operations (`task_limit=1`)

### DIFF
--- a/aiostream/test_utils.py
+++ b/aiostream/test_utils.py
@@ -129,11 +129,15 @@ def event_loop_policy() -> TimeTrackingTestLoopPolicy:
 
 
 @pytest.fixture  # type: ignore[misc]
-def assert_cleanup(
-    event_loop: TimeTrackingTestLoop,
-) -> Callable[[], ContextManager[TimeTrackingTestLoop]]:
+def assert_cleanup() -> Callable[[], ContextManager[TimeTrackingTestLoop]]:
     """Fixture to assert cleanup of resources."""
-    return event_loop.assert_cleanup
+
+    def _assert_cleanup() -> ContextManager[TimeTrackingTestLoop]:
+        loop = asyncio.get_running_loop()
+        assert isinstance(loop, TimeTrackingTestLoop)
+        return loop.assert_cleanup()
+
+    return _assert_cleanup
 
 
 class BaseEventLoopWithInternals(asyncio.BaseEventLoop):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "pytest-asyncio",
+    "pytest-asyncio<1",
     "pytest-cov",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "pytest-asyncio<1",
+    "pytest-asyncio",
     "pytest-cov",
 ]
 
@@ -44,6 +44,7 @@ Homepage = "https://github.com/vxgmichel/aiostream"
 [tool.pytest.ini_options]
 addopts = "--strict-markers --cov aiostream"
 testpaths = ["tests"]
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.pyright]
 strict = [


### PR DESCRIPTION
This affects:
- [concat](https://aiostream.readthedocs.io/en/stable/operators.html#aiostream.stream.concat)
- [flatten](https://aiostream.readthedocs.io/en/stable/operators.html#aiostream.stream.flatten)
- [concatmap](https://aiostream.readthedocs.io/en/stable/operators.html#aiostream.stream.concatmap)
- [flatmap](https://aiostream.readthedocs.io/en/stable/operators.html#aiostream.stream.flatmap)
- [map](https://aiostream.readthedocs.io/en/stable/operators.html#id0)

This is a 7x performance gain when the async function provided to `map` does a simple `sleep(0)`.

See discussion in #130