### PR TITLE
fix: strict `zip` of items that fail on `__eq__`

### DIFF
--- a/aiostream/stream/combine.py
+++ b/aiostream/stream/combine.py
@@ -91,9 +91,9 @@ async def zip(
             if strict:
                 coros = (anext(streamer, STOP_SENTINEL) for streamer in streamers)
                 _items = await asyncio.gather(*coros)
-                if all(item == STOP_SENTINEL for item in _items):
+                if all(isinstance(item, _StopSentinelType) for item in _items):
                     break
-                elif any(item == STOP_SENTINEL for item in _items):
+                elif any(isinstance(item, _StopSentinelType) for item in _items):
                     raise ValueError("The provided sources have different lengths")
                 # This holds because we've ruled out STOP_SENTINEL above:
                 items = cast("list[T]", _items)


### PR DESCRIPTION
Some classes that could be in a stream (eg `polars.DataFrame`) fail on ` __eq__()` with an object of a different type.

Additionally, calling the custom ` __eq__` can be needlessly slow.

Instead, use isinstance to compare against the sentinel value.