### PR TITLE
fix: Use `is` instead of `isinstance`

### DIFF
--- a/aiostream/stream/combine.py
+++ b/aiostream/stream/combine.py
@@ -91,9 +91,9 @@ async def zip(
             if strict:
                 coros = (anext(streamer, STOP_SENTINEL) for streamer in streamers)
                 _items = await asyncio.gather(*coros)
-                if all(isinstance(item, _StopSentinelType) for item in _items):
+                if all(item is STOP_SENTINEL for item in _items):
                     break
-                elif any(isinstance(item, _StopSentinelType) for item in _items):
+                elif any(item is STOP_SENTINEL for item in _items):
                     raise ValueError("The provided sources have different lengths")
                 # This holds because we've ruled out STOP_SENTINEL above:
                 items = cast("list[T]", _items)


### PR DESCRIPTION
https://github.com/vxgmichel/aiostream/pull/135 got merged very quickly (thanks!) and I forgot to switch to simply using `is` for the comparison (which is faster and more appropriate).