### PR TITLE
Await coroutine functions in concatmap/flatmap/switchmap (#129)

### DIFF
--- a/aiostream/stream/advanced.py
+++ b/aiostream/stream/advanced.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from typing import AsyncIterator, AsyncIterable, TypeVar, Union, cast
 from typing_extensions import ParamSpec
 
@@ -17,6 +19,24 @@ __all__ = ["concat", "flatten", "switch", "concatmap", "flatmap", "switchmap"]
 T = TypeVar("T")
 U = TypeVar("U")
 P = ParamSpec("P")
+
+
+def _map_sources(
+    source: AsyncIterable[T],
+    func: combine.MapCallable[T, AsyncIterable[U]],
+    *more_sources: AsyncIterable[T],
+) -> AsyncIterator[AsyncIterable[U]]:
+    """Map ``func`` over the sources, awaiting it when it is a coroutine function.
+
+    The advanced ``*map`` operators expect ``func`` to produce an asynchronous
+    sequence. When ``func`` is a coroutine function, it must be awaited before
+    its result can be iterated, otherwise the un-awaited coroutine is passed
+    downstream and fails the ``AsyncIterable`` check (see issue #129).
+    """
+    if asyncio.iscoroutinefunction(func):
+        return combine.map.raw(source, func, *more_sources)
+    sync_func = cast("combine.SmapCallable[T, AsyncIterable[U]]", func)
+    return combine.smap.raw(source, sync_func, *more_sources)
 
 
 # Helper to manage stream of higher order
@@ -178,7 +198,7 @@ def switch(source: AsyncIterable[AsyncIterable[T]]) -> AsyncIterator[T]:
 @pipable_operator
 def concatmap(
     source: AsyncIterable[T],
-    func: combine.SmapCallable[T, AsyncIterable[U]],
+    func: combine.MapCallable[T, AsyncIterable[U]],
     *more_sources: AsyncIterable[T],
     task_limit: int | None = None,
 ) -> AsyncIterator[U]:
@@ -191,14 +211,14 @@ def concatmap(
     although it's possible to limit the amount of running sequences using
     the `task_limit` argument.
     """
-    mapped = combine.smap.raw(source, func, *more_sources)
+    mapped = _map_sources(source, func, *more_sources)
     return concat.raw(mapped, task_limit=task_limit)
 
 
 @pipable_operator
 def flatmap(
     source: AsyncIterable[T],
-    func: combine.SmapCallable[T, AsyncIterable[U]],
+    func: combine.MapCallable[T, AsyncIterable[U]],
     *more_sources: AsyncIterable[T],
     task_limit: int | None = None,
 ) -> AsyncIterator[U]:
@@ -213,14 +233,14 @@ def flatmap(
 
     Errors raised in a source or output sequence are propagated.
     """
-    mapped = combine.smap.raw(source, func, *more_sources)
+    mapped = _map_sources(source, func, *more_sources)
     return flatten.raw(mapped, task_limit=task_limit)
 
 
 @pipable_operator
 def switchmap(
     source: AsyncIterable[T],
-    func: combine.SmapCallable[T, AsyncIterable[U]],
+    func: combine.MapCallable[T, AsyncIterable[U]],
     *more_sources: AsyncIterable[T],
 ) -> AsyncIterator[U]:
     """Apply a given function that creates a sequence from the elements of one
@@ -231,5 +251,5 @@ def switchmap(
     asynchronous sequence. Errors raised in a source or output sequence (that
     was not already closed) are propagated.
     """
-    mapped = combine.smap.raw(source, func, *more_sources)
+    mapped = _map_sources(source, func, *more_sources)
     return switch.raw(mapped)

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -101,3 +101,42 @@ async def test_switchmap(assert_run, assert_cleanup):
         ys = xs | pipe.switchmap(target2)
         await assert_run(ys[:3], [0, 1, 2])
         assert loop.steps == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_concatmap_with_coroutine_function(assert_run, assert_cleanup):
+    # An `async def` function should be awaited before its result is iterated
+    # (see issue #129).
+    async def target(x: int, *_) -> Stream[int]:
+        return stream.range(x, x + 2)
+
+    with assert_cleanup():
+        xs = stream.range(0, 6, 2)
+        ys = xs | pipe.concatmap(target)
+        await assert_run(ys, [0, 1, 2, 3, 4, 5])
+
+
+@pytest.mark.asyncio
+async def test_flatmap_with_coroutine_function(assert_run, assert_cleanup):
+    # An `async def` function should be awaited before its result is iterated
+    # (see issue #129).
+    async def target(x: int, *_) -> Stream[int]:
+        return stream.range(x, x + 2)
+
+    with assert_cleanup():
+        xs = stream.range(0, 6, 2)
+        ys = xs | pipe.flatmap(target)
+        await assert_run(ys, [0, 1, 2, 3, 4, 5])
+
+
+@pytest.mark.asyncio
+async def test_switchmap_with_coroutine_function(assert_run, assert_cleanup):
+    # An `async def` function should be awaited before its result is iterated
+    # (see issue #129).
+    async def target(x: int, *_) -> Stream[int]:
+        return stream.range(x, x + 2)
+
+    with assert_cleanup():
+        xs = stream.range(0, 6, 2)
+        ys = xs | pipe.switchmap(target)
+        await assert_run(ys, [0, 1, 2, 3, 4, 5])


### PR DESCRIPTION
Fixes #129

## Root cause

`concatmap`, `flatmap` and `switchmap` build their intermediate stream via
`combine.smap.raw` — the *synchronous* map that yields `func(*item)` without
ever awaiting it:

```python
# aiostream/stream/combine.py
async def smap(source, func, *more_sources):
    ...
    async for item in streamer:
        yield func(*item)          # not awaited
```

When `func` is an `async def`, `func(*item)` returns a coroutine object rather
than an `AsyncIterable`. That coroutine is passed downstream to `base_combine`,
where it trips `assert isinstance(result, AsyncIterable)` in
`aiostream/stream/advanced.py`, and a `RuntimeWarning: coroutine '...' was
never awaited` is emitted. `stream.map` already handles this case by detecting
a coroutine function with `asyncio.iscoroutinefunction` and routing to the
async path; the advanced `*map` operators did not.

## Reproduction

```python
import asyncio
import warnings
from aiostream import stream, pipe


async def async_processor(x):
    await asyncio.sleep(0)
    return stream.iterate([x, x * 10])


async def main():
    warnings.simplefilter("error", RuntimeWarning)
    source = stream.range(0, 3)
    pipeline = source | pipe.flatmap(async_processor)
    async with pipeline.stream() as streamer:
        result = [item async for item in streamer]
    print("RESULT:", sorted(result))


asyncio.run(main())
```

Actual output before the fix:

```
FAILED: AssertionError:
Exception ignored while finalizing coroutine <coroutine object async_processor ...>:
RuntimeWarning: coroutine 'async_processor' was never awaited
```

Output after the fix (matching the equivalent synchronous function, which was
already supported):

```
RESULT: [0, 0, 1, 2, 10, 20]
```

## Fix

Added a small `_map_sources` helper in `aiostream/stream/advanced.py` that
routes through `combine.map.raw` when the function is a coroutine function
(detected with `asyncio.iscoroutinefunction`, the same idiom `combine.map`
uses) and keeps using `combine.smap.raw` otherwise. All three advanced `*map`
operators now go through this helper, and their `func` annotation is broadened
from `SmapCallable` to `MapCallable` to reflect that a coroutine function is
now accepted (again mirroring `stream.map`).

The change is localized: the synchronous path is byte-for-byte equivalent to
the previous behaviour, and the async path reuses the already-tested `map`/
`amap` machinery, so the coroutine is awaited before its `AsyncIterable`
result is iterated. The `task_limit` argument is intentionally left to govern
the outer `flatten`/`concat`/`switch` stage, exactly as before.

## Tests

Added `test_concatmap_with_coroutine_function`,
`test_flatmap_with_coroutine_function` and
`test_switchmap_with_coroutine_function` in `tests/test_advanced.py`. Each
passes an `async def` function to the operator and asserts the flattened
output. All three fail on the unmodified code (with the "coroutine was never
awaited" warning) and pass with the fix. The full existing suite continues to
pass (`112 passed`), and `black`, `ruff`, `flake8`, `mypy --strict` and
`pyright` are clean on the changed files.

Disclosure: prepared with AI assistance; reviewed and verified locally.
